### PR TITLE
Make pipeline/geotrellis/bootstrap a public folder

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -97,7 +97,7 @@ module "pipeline_bucket" {
       }
   }]
   tags           = local.tags
-  public_folders = ["geotrellis/jars/", "geotrellis/results/", "fires/"]
+  public_folders = ["geotrellis/jars/", "geotrellis/results/", "geotrellis/bootstrap/", "fires/"]
 }
 
 module "data-lake-test-bucket" {


### PR DESCRIPTION
So other accounts can use geotrellis jar. E.g. wri main account needs to use the bootstrap script for the ArcPy client. We could also copy the script there, but since the account is already using the jar folder in the gfw production account, I think it makes sense to use the corresponding bootstrap script so they don't get out of sync. 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The folder is private


## What is the new behavior?
The folder will be public

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

