### PR TITLE
Upgrade postgres aurora to 12.4 and use r6g instance in production

### DIFF
--- a/terraform/modules/postgresql/main.tf
+++ b/terraform/modules/postgresql/main.tf
@@ -7,7 +7,7 @@ resource "aws_rds_cluster" "aurora_cluster" {
 
   cluster_identifier              = "gfw-aurora" # "${var.project}-aurora-cluster"
   engine                          = "aurora-postgresql"
-  engine_version                  = "11.9"
+  engine_version                  = "12.4"
   database_name                   = var.rds_db_name
   master_username                 = var.rds_user_name
   master_password                 = var.rds_password

--- a/terraform/vars/terraform-production.tfvars
+++ b/terraform/vars/terraform-production.tfvars
@@ -1,5 +1,5 @@
 environment                 = "production"
 rds_backup_retention_period = 7
 log_retention_period        = 30
-rds_instance_class          = "db.r5.large"
+rds_instance_class          = "db.r6g.large"
 rds_instance_count          = 2


### PR DESCRIPTION
Tests to upgrade to r6g/12.4 on staging were successful. I was able to import a new vector layer, create a dynamic vector tile cache, and use postgis operations on the query.

I've already upgraded Aurora to 12.4 on dev/staging so that terraform doesn't overwrite the db. We'll need to remember to do this in production before merging.