### PR TITLE
allow batch to communicate with data api dev instances in dev ports

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -144,6 +144,7 @@ module "firewall" {
   tags            = merge({ Job = "Firewall" }, local.tags)
   vpc_cidre_block = module.vpc.cidr_block
   vpc_id          = module.vpc.id
+  environment     =  var.environment
 }
 
 module "api_token_secret" {

--- a/terraform/modules/firewall/main.tf
+++ b/terraform/modules/firewall/main.tf
@@ -56,6 +56,18 @@ resource "aws_security_group_rule" "default_https_egress" {
   security_group_id = aws_security_group.default.id
 }
 
+// Access from AWS Batch to Data API dev instances that run on random ports in this range
+resource "aws_security_group_rule" "dev_data_api_egress" {
+  count            = var.environment == "dev" ? 1 : 0
+  type             = "egress"
+  from_port        = "30000"
+  to_port          = "31000"
+  protocol         = "tcp"
+  cidr_blocks      = ["0.0.0.0/0"]
+
+  security_group_id = aws_security_group.default.id
+}
+
 // Webserver Security Group
 // Ingress for port 80 and 443
 

--- a/terraform/modules/firewall/variables.tf
+++ b/terraform/modules/firewall/variables.tf
@@ -21,3 +21,8 @@ variable "vpc_id" {
 variable "vpc_cidre_block" {
   type = string
 }
+
+variable "environment" {
+  type        = string
+  description = "Name of the environment"
+}


### PR DESCRIPTION
Now that Data API ecs instances are served on random ports on 30000 - 31000 (in a shared load balancer), this adds outbound rule to the default security group that allows batch jobs to reach the API and only applies to dev environment.